### PR TITLE
DIR-4377: Add redirects added before core update

### DIFF
--- a/nginx/conf.d/redirects/redirects.conf
+++ b/nginx/conf.d/redirects/redirects.conf
@@ -193,7 +193,7 @@ rewrite ^/5-reasons-to-watch-the-new-pbs-series-addiction/?$ https://$host/blog/
 rewrite ^/5-shocking-statistics-for-alcohol-awareness-month/?$ https://$host/blog/5-shocking-statistics-for-alcohol-awareness-month/ permanent;
 rewrite ^/5-singers-who-are-in-recovery-from-eating-disorders/?$ https://$host/blog/5-singers-who-are-in-recovery-from-eating-disorders/ permanent;
 rewrite ^/5-socio-cultural-factors-that-cultivate-addiction/?$ https://$host/blog/5-socio-cultural-factors-that-cultivate-addiction/ permanent;
-rewrite ^/5-stages-of-my-cocaine-high/?$ https://$host/blog/5-stages-of-my-cocaine-high/ permanent;
+rewrite ^/5-stages-of-my-cocaine-high/?$ https://$host/drugs/cocaine/ permanent;
 rewrite ^/5-subtle-signs-of-an-eating-disorder/?$ https://$host/blog/5-subtle-signs-of-an-eating-disorder/ permanent;
 rewrite ^/5-telltale-signs-your-teen-is-abusing-meth/?$ https://$host/blog/5-telltale-signs-your-teen-is-abusing-meth/ permanent;
 rewrite ^/5-things-doctors-might-not-tell-you-about-adderall/?$ https://$host/blog/5-things-doctors-might-not-tell-you-about-adderall/ permanent;
@@ -229,7 +229,7 @@ rewrite ^/8-pro-athletes-with-outrageous-gambling-addictions/?$ https://$host/bl
 rewrite ^/9-practical-tips-to-help-pay-the-bills-while-youre-in-rehab/?$ https://$host/blog/9-practical-tips-to-help-pay-the-bills-while-youre-in-rehab/ permanent;
 rewrite ^/a-cautionary-tale-beware-of-the-13th-steppers/?$ https://$host/blog/a-cautionary-tale-beware-of-the-13th-steppers/ permanent;
 rewrite ^/a-complete-history-of-alcohol/?$ https://$host/blog/a-complete-history-of-alcohol/ permanent;
-rewrite ^/a-complete-history-of-cocaine/?$ https://$host/blog/a-complete-history-of-cocaine/ permanent;
+rewrite ^/a-complete-history-of-cocaine/?$ https://$host/blog/a-complete-history-of-crack-cocaine/ permanent;
 rewrite ^/a-complete-history-of-crack-cocaine/?$ https://$host/blog/a-complete-history-of-crack-cocaine/ permanent;
 rewrite ^/a-complete-history-of-heroin/?$ https://$host/blog/a-complete-history-of-heroin/ permanent;
 rewrite ^/a-complete-history-of-lsd/?$ https://$host/blog/a-complete-history-of-lsd/ permanent;
@@ -334,7 +334,7 @@ rewrite ^/about/cigna-insurance-coverage-for-opiates-opioids/?$ https://$host/in
 rewrite ^/about/cigna-rehab-and-detox-coverage/?$ https://$host/insurance-coverage/cigna/ permanent;
 rewrite ^/about/clonidine-rehab/?$ https://$host/treatment/clonidine/ permanent;
 rewrite ^/about/cobra-rehab-and-detox-coverage/?$ https://$host/insurance-coverage/cobra/ permanent;
-rewrite ^/about/cocaine-rehab/?$ https://$host/treatment/cocaine/ permanent;
+rewrite ^/about/cocaine-rehab/?$ https://$host/drugs/cocaine/treatment/ permanent;
 rewrite ^/about/codeine-addiction-and-treatment/?$ https://$host/addiction-and-treatment/codeine/ permanent;
 rewrite ^/about/codeine-rehab/?$ https://$host/treatment/codeine/ permanent;
 rewrite ^/about/cognitive-behavioral-therapy/?$ https://$host/cognitive-behavioral-therapy/ permanent;
@@ -347,8 +347,8 @@ rewrite ^/about/couples-rehab-centers/?$ https://$host/couples-rehab-centers/ pe
 rewrite ^/about/coventry-info/?$ https://$host/insurance-coverage/ permanent;
 rewrite ^/about/coventry-insurance-coverage-for-eating-disorders/?$ https://$host/insurance-coverage/ permanent;
 rewrite ^/about/coventry-insurance-coverage-for-heroin/?$ https://$host/insurance-coverage/ permanent;
-rewrite ^/about/crack-cocaine-addiction/?$ https://$host/crack-cocaine-addiction/ permanent;
-rewrite ^/about/crack-cocaine-rehab/?$ https://$host/treatment/crack-cocaine/ permanent;
+rewrite ^/about/crack-cocaine-addiction/?$ https://$host/drugs/cocaine/ permanent;
+rewrite ^/about/crack-cocaine-rehab/?$ https://$host/drugs/cocaine/treatment/ permanent;
 rewrite ^/about/crystal-meth-rehab/?$ https://$host/treatment/crystal-meth/ permanent;
 rewrite ^/about/cutting-rehab/?$ https://$host/what-can-be-treated/ permanent;
 rewrite ^/about/darvon-rehab/?$ https://$host/ permanent;
@@ -2820,10 +2820,10 @@ rewrite ^/blog/claim-a-listing/?$ https://$host/contact-us/ permanent;
 rewrite ^/blog/co-occurring-disorder-2/?$ https://$host/treatment/co-occurring-disorders/ permanent;
 rewrite ^/blog/co-occurring-disorder-treatment/?$ https://$host/treatment/co-occurring-disorders/ permanent;
 rewrite ^/blog/co-occurring-disorder/?$ https://$host/treatment/co-occurring-disorders/ permanent;
-rewrite ^/blog/cocaine-2-2/?$ https://$host/treatment/cocaine/ permanent;
-rewrite ^/blog/cocaine-2/?$ https://$host/treatment/cocaine/ permanent;
-rewrite ^/blog/cocaine-4/?$ https://$host/treatment/cocaine/ permanent;
-rewrite ^/blog/cocaine-6/?$ https://$host/treatment/cocaine/ permanent;
+rewrite ^/blog/cocaine-2-2/?$ https://$host/drugs/cocaine/treatment/ permanent;
+rewrite ^/blog/cocaine-2/?$ https://$host/drugs/cocaine/treatment/ permanent;
+rewrite ^/blog/cocaine-4/?$ https://$host/drugs/cocaine/treatment/ permanent;
+rewrite ^/blog/cocaine-6/?$ https://$host/drugs/cocaine/treatment/ permanent;
 rewrite ^/blog/college-students/?$ https://$host/addiction/drug-use-college-students/ permanent;
 rewrite ^/blog/commitment-to-ethics/?$ https://$host/our-brand-promise/ permanent;
 rewrite ^/blog/connecticare/?$ https://$host/insurance-coverage/connecticare/ permanent;
@@ -2922,7 +2922,7 @@ rewrite ^/blog/methadone-treatment/?$ https://$host/treatment/crystal-meth/ perm
 rewrite ^/blog/mvp-health-care/?$ https://$host/insurance-coverage/mvp-health-care/ permanent;
 rewrite ^/blog/our-review-process/?$ https://$host/admissions/ permanent;
 rewrite ^/blog/parents-guide-to-modern-drug-paraphenalia/?$ https://$host/blog/ permanent;
-rewrite ^/blog/parents-guide-to-what-cocaine-crack-meth-heroin-and-other-drugs-smell-like/?$ https://$host/treatment/cocaine/ permanent;
+rewrite ^/blog/parents-guide-to-what-cocaine-crack-meth-heroin-and-other-drugs-smell-like/?$ https://$host/drugs/cocaine/treatment/ permanent;
 rewrite ^/blog/paying-for-treatment-2/?$ https://$host/blog/how-can-i-go-to-rehab-without-insurance/ permanent;
 rewrite ^/blog/paying-for-treatment/?$ https://$host/blog/how-can-i-go-to-rehab-without-insurance/ permanent;
 rewrite ^/blog/pornography-2/?$ https://$host/blog/ permanent;
@@ -4560,6 +4560,24 @@ rewrite ^/local/university-city-mo/?$ https://$host/local/ permanent;
 rewrite ^/adderall-addiction-quiz/?$ https://$host/self-assessment/ permanent;
 rewrite ^/blog/alcohol-poisoning-3-things-to-expect-during-your-er-visit/?$ https://$host/alcohol/overdose/ permanent;
 rewrite ^/alcohol-poisoning-3-things-to-expect-during-your-er-visit/?$ https://$host/alcohol/overdose/ permanent;
+
+## DLB-2955
+rewrite ^/drugs/cocaine/long-term-effects/?$ https://$host/drugs/cocaine/effects/ permanent;
+rewrite ^/drugs/cocaine/shooting/?$ https://$host/drugs/cocaine/routes-of-use/ permanent;
+rewrite ^/drugs/cocaine/snorting/?$ https://$host/drugs/cocaine/routes-of-use/ permanent;
+rewrite ^/drugs/cocaine/deviated-septum/?$ https://$host/drugs/cocaine/routes-of-use/ permanent;
+rewrite ^/treatment/cocaine/?$ https://$host/drugs/cocaine/treatment permanent;
+rewrite ^/blog/a-complete-history-of-cocaine/?$ https://$host/blog/a-complete-history-of-crack-cocaine/ permanent;
+rewrite ^/blog/street-names-and-nicknames-for-cocaine/?$ https://$host/drugs/cocaine/ permanent;
+rewrite ^/blog/5-stages-of-my-cocaine-high/?$ https://$host/drugs/cocaine/ permanent;
+rewrite ^/drugs/cocaine/signs-of-abuse/?$ https://$host/drugs/cocaine/ permanent;
+rewrite ^/cocaine-hotline/?$ https://$host/drugs/cocaine/ permanent;
+rewrite ^/drugs/crack-cocaine/?$ https://$host/drugs/cocaine/ permanent;
+rewrite ^/crack-cocaine-addiction/?$ https://$host/drugs/cocaine/ permanent;
+rewrite ^/drugs/cocaine/what-is-it-cut-with/?$ https://$host/drugs/cocaine/ permanent;
+rewrite ^/treatment/luxury-cocaine/?$ https://$host/drugs/cocaine/treatment/ permanent;
+rewrite ^/treatment/crack-cocaine/?$ https://$host/drugs/cocaine/treatment permanent;
+rewrite ^/cocaine-addiction-quiz/?$ https://$host/self-assessment/cocaine-addiction-quiz/ permanent;
 
 # DLC-545
 rewrite ^/listings/aps-clinics-of-puerto-rico-manati-1095059777/?$ https://$host/local/ permanent;

--- a/nginx/conf.d/redirects/redirects.conf
+++ b/nginx/conf.d/redirects/redirects.conf
@@ -288,7 +288,6 @@ rewrite ^/about/alcohol-and-sexual-assault/?$ https://$host/alcohol-and-sexual-a
 rewrite ^/about/alcohol-rehab-insurance-coverage/?$ https://$host/alcohol-rehab-insurance-coverage/ permanent;
 rewrite ^/about/alcohol-rehab/?$ https://$host/alcohol/treatment/ permanent;
 rewrite ^/treatment/alcohol/?$ https://$host/alcohol/treatment/ permanent;
-rewrite ^/about/alprazolam-rehab/?$ https://$host/treatment/alprazolam/ permanent;
 rewrite ^/about/ambien-addiction-treatment/?$ https://$host/treatment/ambien/ permanent;
 rewrite ^/about/ambien-rehab/?$ https://$host/treatment/ambien/ permanent;
 rewrite ^/about/american-addiction-centers-reviews/?$ https://$host/addiction/american-addiction-centers-reviews/ permanent;
@@ -322,7 +321,6 @@ rewrite ^/about/butalbital-rehab/?$ https://$host/treatment/butalbital/ permanen
 rewrite ^/about/butorphanol-rehab/?$ https://$host/treatment/butorphanol/ permanent;
 rewrite ^/about/campral-rehab/?$ https://$host/treatment/campral/ permanent;
 rewrite ^/about/carisoprodol-rehab/?$ https://$host/treatment/carisoprodol/ permanent;
-rewrite ^/about/chlordiazepoxide-rehab/?$ https://$host/treatment/chlordiazepoxide/ permanent;
 rewrite ^/about/choosing-the-best-couples-rehab-center/?$ https://$host/couples-rehab-centers/ permanent;
 rewrite ^/about/choosing-the-right-rehab/?$ https://$host/treatment/choosing/ permanent;
 rewrite ^/about/christian-rehab-centers/?$ https://$host/christian-rehab-centers/ permanent;
@@ -371,7 +369,6 @@ rewrite ^/about/financing-addiction-treatment/?$ https://$host/addiction/financi
 rewrite ^/about/fioricet-abuse-and-treatment/?$ https://$host/treatment/fioricet/ permanent;
 rewrite ^/about/first-care-rehab-and-detox-coverage/?$ https://$host/insurance-coverage/ permanent;
 rewrite ^/about/first-health-network-rehab-and-detox-coverage/?$ https://$host/insurance-coverage/first-health-network/ permanent;
-rewrite ^/about/flunitrazepam-rehab/?$ https://$host/treatment/flunitrazepam/ permanent;
 rewrite ^/about/frequently-asked-questions-about-addiction-rehabilitation/?$ https://$host/addiction/frequently-asked-questions-about-rehabilitation/ permanent;
 rewrite ^/about/gambling-addiction-rehabs/?$ https://$host/addiction/gambling-rehabs/ permanent;
 rewrite ^/about/gay-lesbian-bisexual-transgender-rehab/?$ https://$host/treatment/gay-lesbian-bisexual-transgender/ permanent;
@@ -393,8 +390,6 @@ rewrite ^/about/guide-kratom-addiction-treatment/?$ https://$host/guide/guide-kr
 rewrite ^/about/guide-marijuana-addiction-treatment/?$ https://$host/guide/guide-marijuana-addiction-treatment/ permanent;
 rewrite ^/about/guide-mushroom-addiction-treatment/?$ https://$host/guide/guide-mushroom-addiction-treatment/ permanent;
 rewrite ^/about/guide-steroids-abuse-treatment/?$ https://$host/treatment/steroid/ permanent;
-rewrite ^/about/halcion-addiction-and-treatment/?$ https://$host/addiction-and-treatment/halcion/ permanent;
-rewrite ^/about/halcion-rehab/?$ https://$host/treatment/halcion/ permanent;
 rewrite ^/about/hashish-abuse-and-treatment/?$ https://$host/guide/guide-marijuana-addiction-treatment/ permanent;
 rewrite ^/about/hcsc-insurance-coverage-for-opiates-opioids/?$ https://$host/insurance-coverage/ permanent;
 rewrite ^/about/health-net-insurance-coverage-for-alcohol/?$ https://$host/insurance-coverage/health-net/alcohol/ permanent;
@@ -432,11 +427,9 @@ rewrite ^/about/kaiser-permanente-insurance-coverage-for-opiates-opioids/?$ http
 rewrite ^/about/kaiser-permanente-insurance-coverage-for-sex-addiction/?$ https://$host/insurance-coverage/kaiser-permanente/ permanent;
 rewrite ^/about/kaiser-permanente-rehab-and-detox-coverage/?$ https://$host/insurance-coverage/kaiser-permanente/ permanent;
 rewrite ^/about/khat-rehab/?$ https://$host/treatment/khat/ permanent;
-rewrite ^/about/klonopin-addiction-and-treatment/?$ https://$host/addiction-and-treatment/klonopin/ permanent;
 rewrite ^/about/laudanum-rehab/?$ https://$host/treatment/laudanum-rehab/ permanent;
 rewrite ^/about/levacetylmethadol-rehab/?$ https://$host/medication-assisted-treatment/ permanent;
 rewrite ^/about/librium-abuse-and-addiction/?$ https://$host/librium-abuse-and-addiction/ permanent;
-rewrite ^/about/librium-rehab/?$ https://$host/treatment/librium/ permanent;
 rewrite ^/about/lifesynch-rehab-and-detox-coverage/?$ https://$host/insurance-coverage/ permanent;
 rewrite ^/about/llicit-drug-addiction-and-treatment/?$ https://$host/treatment/and-illicit-drug-addiction/ permanent;
 rewrite ^/about/lorcet-rehab/?$ https://$host/treatment/hydrocodone/ permanent;
@@ -517,8 +510,6 @@ rewrite ^/about/residential-inpatient-programs/?$ https://$host/residential-inpa
 rewrite ^/about/resort-rehab/?$ https://$host/treatment/resort/ permanent;
 rewrite ^/about/ritalin-addiction-and-treatment/?$ https://$host/addiction-and-treatment/ritalin/ permanent;
 rewrite ^/about/ritalin-rehab/?$ https://$host/treatment/ritalin/ permanent;
-rewrite ^/about/rohypnol-abuse-and-treatment/?$ https://$host/treatment/rohypnol/ permanent;
-rewrite ^/about/rohypnol-rehab/?$ https://$host/treatment/rohypnol/ permanent;
 rewrite ^/about/roxicodone-rehab/?$ https://$host/treatment/roxicodone/ permanent;
 rewrite ^/about/secobarbital-rehab/?$ https://$host/treatment/secobarbital/ permanent;
 rewrite ^/about/seconal-rehab/?$ https://$host/treatment/seconal/ permanent;
@@ -548,7 +539,6 @@ rewrite ^/about/the-addiction-rehabilitation-process/?$ https://$host/addiction/
 rewrite ^/about/tramadol-rehab/?$ https://$host/treatment/tramadol/ permanent;
 rewrite ^/about/tramal-rehab/?$ https://$host/treatment/tramadol/ permanent;
 rewrite ^/about/tranquilizer-rehab/?$ https://$host/treatment/tranquilizer/ permanent;
-rewrite ^/about/triazolam-rehab/?$ https://$host/treatment/triazolam/ permanent;
 rewrite ^/about/tussionex-rehab/?$ https://$host/treatment/hydrocodone/ permanent;
 rewrite ^/about/types-of-addiction-treatment-programs/?$ https://$host/addiction/types-of-treatment-programs/ permanent;
 rewrite ^/about/umr-rehab-and-detox-coverage/?$ https://$host/insurance-coverage/umr/ permanent;
@@ -558,7 +548,6 @@ rewrite ^/about/unitedhealth-insurance-coverage-for-cocaine/?$ https://$host/ins
 rewrite ^/about/unitedhealth-insurance-coverage-for-sex-addiction/?$ https://$host/insurance-coverage/unitedhealth-group/ permanent;
 rewrite ^/about/valium-addiction-and-treatment/?$ https://$host/benzodiazepines/valium/ permanent;
 rewrite ^/addiction-and-treatment/valium/?$ https://$host/benzodiazepines/valium/ permanent;
-rewrite ^/about/valium-rehab/?$ https://$host/treatment/valium/ permanent;
 rewrite ^/about/valueoptions-rehab-and-detox-coverage/?$ https://$host/insurance-coverage/ permanent;
 rewrite ^/about/veterans-drug-abuse/?$ https://$host/veterans-drug-abuse/ permanent;
 rewrite ^/about/vicodin-rehab/?$ https://$host/treatment/vicodin/ permanent;
@@ -2545,7 +2534,6 @@ rewrite ^/about/dextroamphetamine-abuse-and-addiction/?$ https://$host/dextroamp
 rewrite ^/about/dextroamphetamine-rehab/?$ https://$host/treatment/dextroamphetamine/ permanent;
 rewrite ^/about/dextropropoxyphene-rehab/?$ https://$host/treatment/opioid/ permanent;
 rewrite ^/about/dextrostat-rehab/?$ https://$host/treatment/dextroamphetamine/ permanent;
-rewrite ^/about/diazepam-rehab/?$ https://$host/treatment/valium/ permanent;
 rewrite ^/about/dilaudid-addiction-and-treatment/?$ https://$host/addiction-and-treatment/dilaudid/ permanent;
 rewrite ^/about/disulfiram-rehab/?$ https://$host/treatment/disulfiram/ permanent;
 rewrite ^/about/dmt-rehab/?$ https://$host/treatment/dmt/ permanent;
@@ -3092,7 +3080,6 @@ rewrite ^/pro-talk/treating-the-high-functioning-addict/?$ https://$host/alcohol
 rewrite ^/addiction/luxury-drug-treatment/?$ https://$host/treatment/luxury-rehab-centers/ permanent;
 rewrite ^/addiction/luxury-rehabilitation/?$ https://$host/treatment/luxury-rehab-centers/ permanent;
 rewrite ^/treatment/luxury-treatment-centers/?$ https://$host/treatment/luxury-rehab-centers/ permanent;
-rewrite ^/treatment/diazepam/?$ https://$host/treatment/valium/ permanent;
 rewrite ^/assessments/?$ https://$host/self-assessment/ permanent;
 rewrite ^/treatment/alcohol-rehab-center/esp/?$ https://$host/alcohol/treatment/esp/ permanent;
 #REH-4172
@@ -4491,7 +4478,6 @@ rewrite ^/guide/guide-steroids-abuse-treatment/?$ https://$host/treatment/steroi
 rewrite ^/addiction-and-treatment/therapy/?$ https://$host/treatment/therapy/ permanent;
 rewrite ^/addiction-treatment-resources/taxi-and-bus-drivers/?$ https://$host/addiction-treatment-resources/those-in-public-transportation/ permanent;
 rewrite ^/addiction-treatment-resources/human-resources-hr/?$ https://$host/addiction-treatment-resources/businesses/ permanent;
-rewrite ^/addiction-and-treatment/prescription/guide-to-ativan-abuse-treatment/?$ https://$host/benzodiazepines/ativan/ permanent;
 
 ## https://recoverybrands.atlassian.net/browse/DLB-59
 rewrite ^/pro-talk/getting-your-brain-back-together-after-benzo-withdrawal/?$ https://$host/benzodiazepines/effects/brain/ permanent;
@@ -4560,24 +4546,6 @@ rewrite ^/local/university-city-mo/?$ https://$host/local/ permanent;
 rewrite ^/adderall-addiction-quiz/?$ https://$host/self-assessment/ permanent;
 rewrite ^/blog/alcohol-poisoning-3-things-to-expect-during-your-er-visit/?$ https://$host/alcohol/overdose/ permanent;
 rewrite ^/alcohol-poisoning-3-things-to-expect-during-your-er-visit/?$ https://$host/alcohol/overdose/ permanent;
-
-## DLB-2955
-rewrite ^/drugs/cocaine/long-term-effects/?$ https://$host/drugs/cocaine/effects/ permanent;
-rewrite ^/drugs/cocaine/shooting/?$ https://$host/drugs/cocaine/routes-of-use/ permanent;
-rewrite ^/drugs/cocaine/snorting/?$ https://$host/drugs/cocaine/routes-of-use/ permanent;
-rewrite ^/drugs/cocaine/deviated-septum/?$ https://$host/drugs/cocaine/routes-of-use/ permanent;
-rewrite ^/treatment/cocaine/?$ https://$host/drugs/cocaine/treatment permanent;
-rewrite ^/blog/a-complete-history-of-cocaine/?$ https://$host/blog/a-complete-history-of-crack-cocaine/ permanent;
-rewrite ^/blog/street-names-and-nicknames-for-cocaine/?$ https://$host/drugs/cocaine/ permanent;
-rewrite ^/blog/5-stages-of-my-cocaine-high/?$ https://$host/drugs/cocaine/ permanent;
-rewrite ^/drugs/cocaine/signs-of-abuse/?$ https://$host/drugs/cocaine/ permanent;
-rewrite ^/cocaine-hotline/?$ https://$host/drugs/cocaine/ permanent;
-rewrite ^/drugs/crack-cocaine/?$ https://$host/drugs/cocaine/ permanent;
-rewrite ^/crack-cocaine-addiction/?$ https://$host/drugs/cocaine/ permanent;
-rewrite ^/drugs/cocaine/what-is-it-cut-with/?$ https://$host/drugs/cocaine/ permanent;
-rewrite ^/treatment/luxury-cocaine/?$ https://$host/drugs/cocaine/treatment/ permanent;
-rewrite ^/treatment/crack-cocaine/?$ https://$host/drugs/cocaine/treatment permanent;
-rewrite ^/cocaine-addiction-quiz/?$ https://$host/self-assessment/cocaine-addiction-quiz/ permanent;
 
 # DLC-545
 rewrite ^/listings/aps-clinics-of-puerto-rico-manati-1095059777/?$ https://$host/local/ permanent;
@@ -4720,4 +4688,4 @@ rewrite ^/crack-cocaine-addiction/?$ https://$host/drugs/cocaine/ permanent;
 rewrite ^/drugs/cocaine/what-is-it-cut-with/?$ https://$host/drugs/cocaine/ permanent;
 rewrite ^/treatment/luxury-cocaine/?$ https://$host/drugs/cocaine/treatment/ permanent;
 rewrite ^/treatment/crack-cocaine/?$ https://$host/drugs/cocaine/treatment permanent;
-rewrite ^/cocaine-addiction-quiz/?$ https://$host/assessments/cocaine-addiction-quiz/ permanent;
+rewrite ^/cocaine-addiction-quiz/?$ https://$host/self-assessment/cocaine-addiction-quiz/ permanent;


### PR DESCRIPTION
I cleaned up redundant redirects for the redirects that should have been added via these tasks:
https://recoverybrands.atlassian.net/browse/DLB-2405
https://recoverybrands.atlassian.net/browse/DIR-2955