### PR TITLE
RHB-1294 add redirect from rehabs-com to editorial-staff

### DIFF
--- a/nginx/conf.d/redirects/redirects.conf
+++ b/nginx/conf.d/redirects/redirects.conf
@@ -5312,3 +5312,6 @@ rewrite ^/snorting/?$ https://$host/addiction/snorting/ permanent;
 rewrite ^/medication-assisted-treatment/?$ https://$host/treatment/medication/mat/ permanent;
 rewrite ^/guide-to-fioricet-abuse-and-treatment/?$ https://$host/drugs/barbiturate/ permanent;
 rewrite ^/guide-to-ghb-abuse-treatment-options/?$ https://$host/sedatives/treatment/ permanent;
+
+#RHB-1294
+rewrite ^/contributors/rehabs-com/?$ https://$host/contributors/editorial-staff/ permanent;


### PR DESCRIPTION
https://recoverybrands.atlassian.net/browse/RHB-1294

I transferred rehabs-com authored posts/pages to editorial-staff and removed the rehabs-com user so I added a redirect from /contributors/rehabs-com/ to /contributors/editorial-staff/